### PR TITLE
Added two missing pets and fixed a tiny typo

### DIFF
--- a/CharacterData.cs
+++ b/CharacterData.cs
@@ -33,7 +33,7 @@ namespace CharacterEditor
 		// Entity IDs found at: https://docs.google.com/spreadsheet/lv?key=0As7kattQ9kwbdFp6ZTlzV0R1RVRaZklBbmZZb2lBZ2c&f=true&noheader=true&gid=5
 		public static readonly List<byte> PetKinds = new List<byte>
 		{
-			0, 19, 20, 22, 23, 25, 26, 27, 28, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 50, 53, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 73, 74, 75, 85, 86, 87, 88, 89, 90, 91, 92, 93, 98, 99, 104, 105, 106, 151
+			0, 19, 20, 22, 23, 25, 26, 27, 28, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 50, 53, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 73, 74, 75, 85, 86, 87, 88, 89, 90, 91, 92, 93, 98, 99, 102, 103, 104, 105, 106, 151
 		};
 
 		public CharacterData(int index)

--- a/FormEditor.Designer.cs
+++ b/FormEditor.Designer.cs
@@ -194,7 +194,7 @@
             this.comboBoxRace.Items.AddRange(new object[] {
             "Human",
             "Elf",
-            "Dwaf",
+            "Dwarf",
             "Orc",
             "Goblin",
             "Lizard",

--- a/FormEditor.Designer.cs
+++ b/FormEditor.Designer.cs
@@ -423,6 +423,8 @@
             "Penguin",
             "Horse",
             "Camel",
+            "Beetle (Bark)",
+            "Beetle (Fire)",
             "Beetle (Snout)",
             "Beetle (Lemon)",
             "Crab",


### PR DESCRIPTION
I crashed while editing my save since I had a Bark Beetle and your program threw an IndexOutOfRange. I might make another patch to handle unidentified pets better unless you want to.

I might also run a comparison between the [the Pet wiki page](http://cubeworldwiki.net/index.php/Category:Pets) and the [Entity ID spreadsheet](https://docs.google.com/spreadsheet/lv?key=0As7kattQ9kwbdFp6ZTlzV0R1RVRaZklBbmZZb2lBZ2c&f=true&noheader=true&gid=5) and add all the missing pets.

I tested the code and it seems to be working fine and I was able to assign Bark Beetle.
